### PR TITLE
Add Support for the Pump Shotgun (Cartel Update)

### DIFF
--- a/EZCrosshair/Core.cs
+++ b/EZCrosshair/Core.cs
@@ -14,7 +14,7 @@ namespace EZCrosshair
 	public class Core : MelonMod
 	{
 		/* List of ranged weapon IDs to compare with the hotbar item ID */
-		private static readonly string[] crosshairIdList = { "revolver", "m1911", "ak47" };
+		private static readonly string[] crosshairIdList = { "revolver", "m1911", "ak47", "pumpshotgun" };
 
 		private const bool debugMode = false;
 


### PR DESCRIPTION
As the title says, this simply adds "pumpshotgun" to the list of ranged weapon IDs.

Should fix #4.